### PR TITLE
remove line end in the public_key

### DIFF
--- a/src/CWOMService.js
+++ b/src/CWOMService.js
@@ -15,7 +15,7 @@ var severitys = ["CRITICAL", "MAJOR", "MINOR"];
 
 // Load Public/Private Keys
 const fs = require('fs');
-isHelper.setPublicKey(fs.readFileSync('./keys/iwo_public_key.txt', 'utf8'));
+isHelper.setPublicKey(fs.readFileSync('./keys/iwo_public_key.txt', 'utf8').replace(/\n/g,""));
 isHelper.setPrivateKey(fs.readFileSync('./keys/iwo_private_key.pem', 'utf8'));
 
 


### PR DESCRIPTION
on linux there will be a \n after the public_key that creates a problem in the header as shown below.

```
{
  method: 'GET',
  url: 'https://intersight.com/wo/api/v3/supplychains?uuids=73831516414466&detail_type=entity&health=true',
  body: '',
  headers: {
    Accept: 'application/json',
    Host: 'intersight.com',
    Date: 'Thu, 11 Mar 2021 21:23:57 GMT',
    Digest: 'SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
    Authorization: 'Signature keyId="59a54d27f11aa1000179b0a4/5f3394f17564612d339b11f3/5f3d7ced7564612d33f41979\n' +
      '",algorithm="rsa-sha256",headers="(request-target) date digest host",signature="hxMB
```

removing the rest of the output for security reasons, but you can see there is a \n after the public key and this is messing up the Authorization Header.

Did a small fix for this