### PR TITLE
Fixed example config,json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ References:
 		"iwoServer": 		"https://intersight.com",
 		"iwoAPIPath": 		"/wo/api/v3",
 		"iwoViewEntityURL": "/view/main/"
-	},
+	}
 
 }
 ```


### PR DESCRIPTION
We tried using the default config.json given in the readme and it didn't work because of the extra comma.